### PR TITLE
[bugfix] Global class들 사용 가능하도록 세팅 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,11 @@
 
 - src
   - api: 요청 관련 로직 모음
+  - assets
+    - scss: 공통 스타일 코드(SCSS) 모음
+  - images: 이미지 모음
   - pages: 각 경로의 페이지 component
   - components: 공통 component (Menu, layout, etc.)
   - views: 공통 조합해서 만든 상세한 component
   - model: 데이터 인터페이스 (interface, type 등 모음)
   - utils: 유틸성 로직들
-  - assets: 이미지, 스타일(SCSS) 모음

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+    sassOptions: {
+        // SCSS 파일들에 자동으로 넣을 코드.
+        // prependData 옵션이랑 동일. (additionalData가 더 최신 이름인듯)
+        additionalData: `@import '@/assets/scss/index';`
+    }
+};

--- a/src/assets/scss/_index.scss
+++ b/src/assets/scss/_index.scss
@@ -1,4 +1,8 @@
-// @import 'reset.scss';
+/**
+ * 모든 SCSS 파일들이 공통으로 사용하는 값들.
+ * (next.config.js 참고)
+ */
+
 @import 'font.scss';
 @import 'common.scss';
 @import 'component.scss';

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,10 +1,11 @@
 /**
  * 모든 페이지에서 돌아가는 코드.
  */
-import '@/assets/scss/_index.scss'
 
 import { AppProps } from 'next/app';
 import Head from 'next/head';
+
+import '@/assets/scss/reset.scss'
 
 /**
  * 임의의 page의 wrapper.

--- a/src/views/home/SeekerSection.module.scss
+++ b/src/views/home/SeekerSection.module.scss
@@ -9,7 +9,7 @@
 .sectionTitle {
     font-size: 32px;
 
-    color: green;
+    @extend .font, .green;
 }
 
 .sectionTitleEmphasize {
@@ -22,7 +22,7 @@
     margin-top: 16px;
     font-size: 12px;
 
-    color: gray;
+    @extend .font, .gray9;
 }
 
 .seekerCards {


### PR DESCRIPTION
* 문제
  * .font, .green 등의 global class들을 사용하고자 함
  * 근데 .tsx에서 import하는 걸로는 사용이 안됨
  * .scss에서 직접 import하니 reset.scss가 scoped scss(*.module.scss)랑  안 맞음
* 해결
  * reset.scss: _app.tsx에서 import하도록 수정
  * Next.js 옵션 수정하여 import문을 SCSS 파일들에 자동 삽입
    * sass-loader의 additionalData 옵션 사용
    * SCSS 파일들 앞에 자동으로 들어갈 코드 정의 가능
    * https://stackoverflow.com/questions/60951575/next-js-using-sass-variables-from-global-scss/65467413#65467413